### PR TITLE
Allow to override the default renderers

### DIFF
--- a/src/render.tsx
+++ b/src/render.tsx
@@ -261,7 +261,7 @@ const renderHtml = (
     collapse: true,
     resetStyles: false,
     ...options,
-    renderers: { ...options.renderers, ...renderers },
+    renderers: { ...renderers, ...options.renderers },
     stylesheets: [baseStyles, ...stylesheets, ...parsed.stylesheets],
   };
 


### PR DESCRIPTION
Would be very nice to have an ability to override the default renderers with custom ones. Currently it isn't allowed, the default renderers always take precedence.