### PR TITLE
Support superscript and subscript tags (sup and sub) as inline elements

### DIFF
--- a/src/tags.ts
+++ b/src/tags.ts
@@ -32,6 +32,8 @@ export type Tag =
   | 'dfn'
   | 'code'
   | 'abbr'
+  | 'sup'
+  | 'sub'
   | 'a'
   | 'img'
   | 'ul'
@@ -91,6 +93,8 @@ export const isBlock: Record<Tag, boolean> & Record<string, boolean> = {
   dfn: false,
   code: false,
   abbr: false,
+  sup: false,
+  sub: false,
 
   a: false,
   img: false,


### PR DESCRIPTION
Add the sup and sub tags to the list of supported tags, marked as not block. This will allow them to be rendered as Text elements to support superscript and subscript text.