### PR TITLE
Do not trim whitespace around custom elements

### DIFF
--- a/src/render.test.tsx
+++ b/src/render.test.tsx
@@ -188,6 +188,18 @@ describe('render', () => {
       expect(pText.props.children.length).toBe(8);
     });
 
+    it('Should render keep spaces around custom elements', () => {
+      const html = `<p>Paragraph with <CustomElement /> between text</p>`;
+      const rootView = renderHtml(html, {
+        renderers: {
+          customelement: () => <View />,
+        }
+      });
+      const p = rootView.props.children.props.children;
+      expect(p[0].props.children).toBe('Paragraph with ');
+      expect(p[2].props.children).toBe(' between text');
+    });
+
     it('Should render anchors as inline if their content is inline', () => {
       const html = `<p>Link to <a href="//www.google.com">Google</a> using react-pdf-html.</p>`;
       const rootView = renderHtml(html);

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -75,6 +75,11 @@ export const hasBlockContent = (element: HtmlElement | string): boolean => {
 const ltrim = (text: string): string => text.replace(/^\s+/, '');
 const rtrim = (text: string): string => text.replace(/\s+$/, '');
 
+const isCustomElement = (element?: HtmlElement | string): boolean => {
+  if (!element || typeof element === 'string') return false;
+  return isText[element.tag] === undefined;
+}
+
 /**
  * Groups all block and non-block elements into buckets so that all non-block elements can be rendered in a parent Text element
  * @param elements Elements to place in buckets of block and non-block content
@@ -101,12 +106,17 @@ export const bucketElements = (
             element = element.substr(0, element.length - 1);
           }
         } else {
-          if (hasBlock || hasBlock === undefined) {
+          const isBucketCustomElement = isCustomElement(bucket?.content[0]);
+          if (!isBucketCustomElement && (hasBlock || hasBlock === undefined)) {
             element = ltrim(element);
           }
           const next = elements[index + 1];
-          if (next && hasBlockContent(next)) {
-            element = rtrim(element);
+          
+          if (next) {
+            const isNextCustomElement = isCustomElement(next);
+            if (hasBlockContent(next) && !isNextCustomElement) {
+              element = rtrim(element);
+            }
           }
         }
       }
@@ -115,7 +125,7 @@ export const bucketElements = (
       }
     }
     const block = hasBlockContent(element);
-    if (block !== hasBlock) {
+    if (block !== hasBlock || isCustomElement(element)) {
       hasBlock = block;
       bucket = {
         hasBlock,

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -57,6 +57,7 @@ export type Tag =
 export const isText: Record<Tag, boolean> & Record<string, boolean> = {
   html: false,
   body: false,
+  style: false,
   h1: false,
   h2: false,
   h3: false,


### PR DESCRIPTION
Thanks for the great library! We have a usecase where our HTML has custom React elements inside it, like this:

```html
<p>Paragraph with <CustomElement /> between text</p>
```

And when used with `collapse: true`, `react-pdf-html` will strip the whitespace around the custom element so you end up displaying this in the PDF:

```
<p>Paragraph with<CustomElement />between text</p>
```

This is not desireable. This PR updates the block detection logic so that custom elements are considered as non-block elements to handle this situation gracefully.

I fully recognize that this isn't a fully complete solution as it's possible that your custom element might actually be a block element, but I think supporting that would require very complex recursive logic to review the contents of all children. The implementation in this PR keeps things pretty simple and works for the most basic usecases, which will be enough for us (and hopefully others).

I hope you'll consider this PR and include it in the library! Any feedback is appreciated.
