### PR TITLE
Fix bug that styling with <Html style=...> doesn't work properly

### DIFF
--- a/src/render.tsx
+++ b/src/render.tsx
@@ -293,7 +293,7 @@ const renderHtml = (
   options: {
     collapse?: boolean;
     renderers?: HtmlRenderers;
-    style?: Style | (Style | undefined)[];
+    style?: Style | Style[];
     stylesheet?: HtmlStyles | HtmlStyles[];
     resetStyles?: boolean;
   } = {}
@@ -311,7 +311,7 @@ const renderHtml = (
       return;
     }
     if (typeof style.fontSize === 'number') {
-      fontSizeStyle.fontSize = style.fontSize as unknown as number;
+      fontSizeStyle.fontSize = style.fontSize;
     }
     if (typeof style.fontSize === 'string' && style.fontSize.endsWith('px')) {
       fontSizeStyle.fontSize = parseInt(style.fontSize, 10);
@@ -340,7 +340,7 @@ const renderHtml = (
   applyStylesheets(opts.stylesheets, parsed.rootElement);
 
   return (
-    <View style={{ ...styles, ...fontSizeStyle }}>
+    <View style={[...styles, fontSizeStyle]}>
       {renderElements(parsed.rootElement.content, opts)}
     </View>
   );


### PR DESCRIPTION
The styles given to <Html style={...}/> didn't propagate properly, for example this didn't work:

```tsx
<Html resetStyles style={{color: "red"}} stylesheet={styles}>
  {content}
</Html>
```

That happened because this line (line 343 in src/render.tsx):
```
<View style={{ ...styles, ...fontSizeStyle }}>
```
Per react-pdf docs you can either have style as a single object with css properties such as color, margin, etc ..., or you can have an array of such objects. Right now what happens is that `styles` is an array, e.g. `[{color: 'red'}]`, and `fontSizeStyle` is an object: `{ fontSize:  10 }`

Doing this `{ ...styles, ...fontSizeStyle }` will then result with 
```
{
  "0": {
     color: "red"
   },
   fontSize: 10
}
```
which is not correct per react-pdf docs (and it doesnt work)

Hence the fix :) It works as expected now on my branch