### PR TITLE
Adds svg support to the extent react-pdf does

### DIFF
--- a/src/render.test.tsx
+++ b/src/render.test.tsx
@@ -451,4 +451,155 @@ describe('render', () => {
       }
     });
   });
+
+  it('Should render a PDF with an svg without errors', async () => {
+    const content = `<html>
+      <body>
+        <svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
+          <defs>
+            <linearGradient id="linearGrad" x1="0%" y1="50%" x2="100%" y2="50%">
+              <stop offset="0%" stop-color="red" stop-opacity="1" />
+              <stop offset="100%" style="stop-color:yellow;stop-opacity:1" />
+            </linearGradient>
+
+            <radialGradient id="radialGrad" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" style="stop-color:orange;stop-opacity:1" />
+              <stop offset="100%" style="stop-color:blue;stop-opacity:1" />
+            </radialGradient>
+
+            <clipPath id="starClip">
+              <polygon points="100,10 40,198 190,78 10,78 160,198" />
+            </clipPath> 
+          </defs>
+
+          <rect width="100%" height="100%" fill="url(#linearGrad)" />
+
+          <line x1="30" y1="80" x2="200" y2="250" stroke="black" stroke-width="3" />
+          <polyline points="220,50 280,80 250,150 300,200" fill="none" stroke="green" stroke-width="3" />
+          <polygon points="320,80 340,140 400,120" fill="url(#radialGrad)" /> 
+          <path d="M420,50 C480,80 450,200 400,240" stroke="purple" stroke-width="4" fill="none"/>
+
+          <rect x="230" y="160" width="60" height="30" fill="lightblue" stroke="black" />
+          <circle cx="360" cy="220" r="20" fill="pink" />
+          <ellipse cx="430" cy="260" rx="30" ry="15" fill="brown" />
+
+          <text x="60" y="60" font-size="24">SVG Shapes</text>
+          <text x="90" y="120">
+            <tspan>Multiline</tspan>
+            <tspan x="90" dy="20">Text</tspan> 
+          </text>
+
+          <g clip-path="url(#starClip)">
+            <circle cx="100" cy="100" r="80" fill="#f0f" stroke="black" stroke-width="3" />
+          </g>
+        </svg>
+      </body>
+    </html>`;
+
+    const rootView = renderHtml(content);
+    expect(rootView.type).toBe(View);
+
+    const html = rootView.props.children;
+    expect(html.type).toBe(renderPassThrough);
+
+    const body = html.props.children;
+    expect(body.type).toBe(renderBlock);
+    expect(body.props.element.tag).toBe('body');
+
+    const svg = body.props.children;
+    expect(svg.props.element.tag).toBe('svg');
+    expect(svg.props.element.attributes).toStrictEqual({
+      height: '300',
+      width: '500',
+      xmlns: 'http://www.w3.org/2000/svg',
+    });
+
+    const defs = svg.props.children[0];
+    expect(defs.props.element.tag).toBe('defs');
+    expect(defs.props.element.attributes).toStrictEqual({});
+
+    const linearGradient = defs.props.children[0];
+    expect(linearGradient.props.element.tag).toBe('lineargradient');
+    expect(linearGradient.props.element.attributes).toStrictEqual({
+      id: 'linearGrad',
+      x1: '0%',
+      x2: '100%',
+      y1: '50%',
+      y2: '50%',
+    });
+
+    const lStop1 = linearGradient.props.children[0];
+    expect(lStop1.props.element.tag).toBe('stop');
+    expect(lStop1.props.element.attributes).toStrictEqual({
+      offset: '0%',
+      'stop-color': 'red',
+      'stop-opacity': '1',
+    });
+
+    const lStop2 = linearGradient.props.children[1];
+    expect(lStop2.props.element.tag).toBe('stop');
+    expect(lStop2.props.element.attributes).toStrictEqual({
+      offset: '100%',
+      style: 'stop-color:yellow;stop-opacity:1',
+    });
+
+    const radialGradient = defs.props.children[2];
+    expect(radialGradient.props.element.tag).toBe('radialgradient');
+
+    const rStop1 = radialGradient.props.children[0];
+    expect(rStop1.props.element.tag).toBe('stop');
+
+    const rStop2 = radialGradient.props.children[1];
+    expect(rStop2.props.element.tag).toBe('stop');
+
+    const clipPath = defs.props.children[4];
+    expect(clipPath.props.element.tag).toBe('clippath');
+    const polygonClip = clipPath.props.children;
+    expect(polygonClip.props.element.tag).toBe('polygon');
+
+    const rect = svg.props.children[1];
+    expect(rect.props.element.tag).toBe('rect');
+    const line = svg.props.children[2];
+    expect(line.props.element.tag).toBe('line');
+    const polyline = svg.props.children[3];
+    expect(polyline.props.element.tag).toBe('polyline');
+    const polygon = svg.props.children[4];
+    expect(polygon.props.element.tag).toBe('polygon');
+    const path = svg.props.children[5];
+    expect(path.props.element.tag).toBe('path');
+    const rect2 = svg.props.children[6];
+    expect(rect2.props.element.tag).toBe('rect');
+    const circle = svg.props.children[7];
+    expect(circle.props.element.tag).toBe('circle');
+    const ellipse = svg.props.children[8];
+    expect(ellipse.props.element.tag).toBe('ellipse');
+    const text = svg.props.children[9];
+    expect(text.props.element.tag).toBe('text');
+
+    const textMulti = svg.props.children[10];
+    expect(textMulti.props.element.tag).toBe('text');
+    const tspan1 = textMulti.props.children[0];
+    expect(tspan1.props.element.tag).toBe('tspan');
+    const tspan2 = textMulti.props.children[1];
+    expect(tspan2.props.element.tag).toBe('tspan');
+
+    const g = svg.props.children[11];
+    expect(g.props.element.tag).toBe('g');
+    const gCircle = g.props.children;
+    expect(gCircle.props.element.tag).toBe('circle');
+
+    const document = (
+      <Document>
+        <Page size="LETTER">
+          <>{rootView}</>
+        </Page>
+      </Document>
+    );
+
+    try {
+      const pdfString = await renderToString(document);
+    } catch (e) {
+      fail(e);
+    }
+  });
 });

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -6,18 +6,18 @@ import { createHtmlStylesheet, HtmlStyle, HtmlStyles } from './styles';
 import { Style } from '@react-pdf/types';
 import { isText, Tag } from './tags';
 
-export type BaseHtmlRenderer = {
+export type HtmlRendererProps = {
   element: HtmlElement;
   style: Style[];
   children: React.ReactNode;
   stylesheets: HtmlStyles[];
 };
 
-export type HtmlRenderer = React.FC<React.PropsWithChildren<BaseHtmlRenderer>>;
+export type HtmlRenderer = React.FC<React.PropsWithChildren<HtmlRendererProps>>;
 
 export type WrapperRenderer = (
   Wrapper: React.ElementType,
-  renderer: BaseHtmlRenderer
+  renderer: HtmlRendererProps
 ) => React.ReactElement;
 
 export type HtmlRenderers = Record<Tag | string, HtmlRenderer>;

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -6,13 +6,19 @@ import { createHtmlStylesheet, HtmlStyle, HtmlStyles } from './styles';
 import { Style } from '@react-pdf/types';
 import { isText, Tag } from './tags';
 
-export type HtmlRenderer = React.FC<
-  React.PropsWithChildren<{
-    element: HtmlElement;
-    style: Style[];
-    stylesheets: HtmlStyles[];
-  }>
->;
+export type BaseHtmlRenderer = {
+  element: HtmlElement;
+  style: Style[];
+  children: React.ReactNode;
+  stylesheets: HtmlStyles[];
+};
+
+export type HtmlRenderer = React.FC<React.PropsWithChildren<BaseHtmlRenderer>>;
+
+export type WrapperRenderer = (
+  Wrapper: React.ElementType,
+  renderer: BaseHtmlRenderer
+) => React.ReactElement;
 
 export type HtmlRenderers = Record<Tag | string, HtmlRenderer>;
 
@@ -224,13 +230,38 @@ const isAnchor = (content: HtmlContent | HtmlElement): boolean => {
     : content.tag === 'a';
 };
 
+const isSvgText = (content: HtmlElement | undefined): boolean => {
+  return (
+    [
+      'svg',
+      'line',
+      'polyline',
+      'polygon',
+      'path',
+      'rect',
+      'circle',
+      'ellipse',
+      'text',
+      'tspan',
+      'g',
+      'stop',
+      'defs',
+      'clippath',
+      'lineargradient',
+      'radialgradient',
+    ].indexOf(content?.tag || '') > -1
+  );
+};
+
 export const renderElements = (
   elements: HtmlContent,
   options: HtmlRenderOptions,
   parent?: HtmlElement
 ): RenderedContent | RenderedContent[] => {
   const buckets = bucketElements(elements, options.collapse, parent?.tag);
-  const parentIsText = parent && !isAnchor(parent) && !hasBlockContent(parent);
+  const parentIsText =
+    (parent && !isAnchor(parent) && !hasBlockContent(parent)) ||
+    isSvgText(parent);
 
   const renderedBuckets: (RenderedContent[] | RenderedContent)[] = buckets.map(
     (bucket, bucketIndex) => {

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -231,26 +231,24 @@ const isAnchor = (content: HtmlContent | HtmlElement): boolean => {
 };
 
 const isSvgText = (content: HtmlElement | undefined): boolean => {
-  return (
-    [
-      'svg',
-      'line',
-      'polyline',
-      'polygon',
-      'path',
-      'rect',
-      'circle',
-      'ellipse',
-      'text',
-      'tspan',
-      'g',
-      'stop',
-      'defs',
-      'clippath',
-      'lineargradient',
-      'radialgradient',
-    ].indexOf(content?.tag || '') > -1
-  );
+  return [
+    'svg',
+    'line',
+    'polyline',
+    'polygon',
+    'path',
+    'rect',
+    'circle',
+    'ellipse',
+    'text',
+    'tspan',
+    'g',
+    'stop',
+    'defs',
+    'clippath',
+    'lineargradient',
+    'radialgradient',
+  ].includes(content?.tag || '');
 };
 
 export const renderElements = (

--- a/src/renderers.tsx
+++ b/src/renderers.tsx
@@ -25,6 +25,7 @@ import { HtmlElement } from './parse';
 import { HtmlStyle } from './styles';
 import { lowerAlpha, orderedAlpha, upperAlpha } from './ordered.type';
 import { Style } from '@react-pdf/types';
+const camelize = require('camelize');
 
 export const renderNoop: HtmlRenderer = ({ children }) => <></>;
 
@@ -32,28 +33,13 @@ export const renderPassThrough: React.FC<React.PropsWithChildren<any>> = ({
   children,
 }) => children;
 
-const svgAttributes: Record<string, string> = {
-  'stop-color': 'stopColor',
-  'stop-opacity': 'stopOpacity',
-  'dominant-baseline': 'dominantBaseline',
-  'fill-opacity': 'fillOpacity',
-  'fill-rule': 'fillRule',
-  'stroke-width': 'strokeWidth',
-  'stroke-opacity': 'strokeOpacity',
-  'stroke-linecap': 'strokeLinecap',
-  'stroke-linejoin': 'strokeLinejoin',
-  'stroke-dasharray': 'strokeDasharray',
-  'text-anchor': 'textAnchor',
-  'clip-path': 'clipPath',
-};
 const convertSvgAttributes = (
   attrs: Record<string, string>
 ): Record<string, string> => {
   const result: Record<string, string> = {};
 
   for (const key in attrs) {
-    const newKey = svgAttributes[key] || key;
-    result[newKey] = attrs[key];
+    result[camelize(key)] = attrs[key];
   }
 
   return result;

--- a/src/renderers.tsx
+++ b/src/renderers.tsx
@@ -1,15 +1,81 @@
 import React from 'react';
-import { Link, Text, View, Image } from '@react-pdf/renderer';
-import { HtmlRenderer, HtmlRenderers } from './render';
+import {
+  Link,
+  Text,
+  View,
+  Image,
+  Svg,
+  Path,
+  Polyline,
+  Line,
+  Polygon,
+  G,
+  Tspan,
+  Ellipse,
+  Circle,
+  Rect,
+  Stop,
+  Defs,
+  ClipPath,
+  LinearGradient,
+  RadialGradient,
+} from '@react-pdf/renderer';
+import { HtmlRenderer, HtmlRenderers, WrapperRenderer } from './render';
 import { HtmlElement } from './parse';
 import { HtmlStyle } from './styles';
 import { lowerAlpha, orderedAlpha, upperAlpha } from './ordered.type';
+import { Style } from '@react-pdf/types';
 
 export const renderNoop: HtmlRenderer = ({ children }) => <></>;
 
 export const renderPassThrough: React.FC<React.PropsWithChildren<any>> = ({
   children,
 }) => children;
+
+const svgAttributes: Record<string, string> = {
+  'stop-color': 'stopColor',
+  'stop-opacity': 'stopOpacity',
+  'dominant-baseline': 'dominantBaseline',
+  'fill-opacity': 'fillOpacity',
+  'fill-rule': 'fillRule',
+  'stroke-width': 'strokeWidth',
+  'stroke-opacity': 'strokeOpacity',
+  'stroke-linecap': 'strokeLinecap',
+  'stroke-linejoin': 'strokeLinejoin',
+  'stroke-dasharray': 'strokeDasharray',
+  'text-anchor': 'textAnchor',
+  'clip-path': 'clipPath',
+};
+const convertSvgAttributes = (
+  attrs: Record<string, string>
+): Record<string, string> => {
+  const result: Record<string, string> = {};
+
+  for (const key in attrs) {
+    const newKey = svgAttributes[key] || key;
+    result[newKey] = attrs[key];
+  }
+
+  return result;
+};
+
+const convertSvgStyles = (stylesTags: Style[]): Style => {
+  return stylesTags.reduce((acc, cur) => ({ ...acc, ...cur }), {});
+};
+
+export const renderSvgs: WrapperRenderer = (
+  Wrapper,
+  { element, style, children }
+) => {
+  return (
+    <Wrapper
+      {...convertSvgAttributes(element?.attributes)}
+      {...convertSvgStyles(style)}
+    >
+      {children}
+    </Wrapper>
+  );
+};
 
 export const renderBlock: HtmlRenderer = ({ style, children }) => (
   <View style={style}>{children}</View>
@@ -159,6 +225,22 @@ const renderers: HtmlRenderers = {
   ),
   td: renderCell,
   th: renderCell,
+  svg: renderSvgs.bind(null, Svg),
+  line: renderSvgs.bind(null, Line),
+  polyline: renderSvgs.bind(null, Polyline),
+  polygon: renderSvgs.bind(null, Polygon),
+  path: renderSvgs.bind(null, Path),
+  rect: renderSvgs.bind(null, Rect),
+  circle: renderSvgs.bind(null, Circle),
+  ellipse: renderSvgs.bind(null, Ellipse),
+  text: renderSvgs.bind(null, Text),
+  tspan: renderSvgs.bind(null, Tspan),
+  g: renderSvgs.bind(null, G),
+  stop: renderSvgs.bind(null, Stop),
+  defs: renderSvgs.bind(null, Defs),
+  clippath: renderSvgs.bind(null, ClipPath),
+  lineargradient: renderSvgs.bind(null, LinearGradient),
+  radialgradient: renderSvgs.bind(null, RadialGradient),
 };
 
 export default renderers;

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -51,7 +51,24 @@ export type Tag =
   | 'td'
   | 'th'
   | 'thead'
-  | 'tbody';
+  | 'tbody'
+  | 'svg'
+  | 'line'
+  | 'path'
+  | 'polyline'
+  | 'polygon'
+  | 'path'
+  | 'rect'
+  | 'circle'
+  | 'ellipse'
+  | 'text'
+  | 'tspan'
+  | 'g'
+  | 'stop'
+  | 'defs'
+  | 'clipPath'
+  | 'linearGradient'
+  | 'radialGradient';
 
 // Is the element rendered as a "Text" tag
 export const isText: Record<Tag, boolean> & Record<string, boolean> = {
@@ -114,4 +131,21 @@ export const isText: Record<Tag, boolean> & Record<string, boolean> = {
   dd: false,
   dl: false,
   dt: false,
+
+  svg: false,
+  line: false,
+  polyline: false,
+  polygon: false,
+  path: false,
+  rect: false,
+  circle: false,
+  ellipse: false,
+  text: false,
+  tspan: false,
+  g: false,
+  stop: false,
+  defs: false,
+  clipPath: false,
+  linearGradient: false,
+  radialGradient: false,
 };


### PR DESCRIPTION
Adds renders for each of the SVG components here https://react-pdf.org/svg

Most of the work here is either
* Choosing the correct react-pdf component to render
* Converting attributes to the ones react-pdf wants 
* Or, ensuring that the default text logic (Render <Text /> component) does not take place with an svg.

Test included covers each of the available react-pdf svg components.