### PR TITLE
fix(renderers): remove dots

### DIFF
--- a/src/renderers.tsx
+++ b/src/renderers.tsx
@@ -151,15 +151,11 @@ const renderers: HtmlRenderers = {
       );
     } else if (ordered) {
       if (lowerAlpha.includes(listStyleType)) {
-        bullet = (
-          <Text>{orderedAlpha[element.indexOfType].toLowerCase()}.</Text>
-        );
+        bullet = <Text>{orderedAlpha[element.indexOfType].toLowerCase()}</Text>;
       } else if (upperAlpha.includes(listStyleType)) {
-        bullet = (
-          <Text>{orderedAlpha[element.indexOfType].toUpperCase()}.</Text>
-        );
+        bullet = <Text>{orderedAlpha[element.indexOfType].toUpperCase()}</Text>;
       } else {
-        bullet = <Text>{element.indexOfType + 1}.</Text>;
+        bullet = <Text>{element.indexOfType + 1}</Text>;
       }
     } else {
       // if (listStyleType.includes('square')) {


### PR DESCRIPTION
It's rendering a dot every time we use an ordered list.

Like the image below:
<img width="261" alt="image" src="https://github.com/danomatic/react-pdf-html/assets/47953339/15b0cea0-3269-4cef-ad8b-21c47fefb902">
