### PR TITLE
Font Family Fallback Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "react-pdf-html",
-  "version": "2.0.0",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-pdf-html",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^1.1.3",
         "node-html-parser": "^6.1.13"
       },
       "devDependencies": {
-        "@react-pdf/renderer": "^3.0.0",
+        "@react-pdf/renderer": "^3.4.4",
         "@types/css-tree": "^1.0.7",
         "@types/jest": "^25.2.3",
         "@types/node": "^14.0.25",
@@ -33,7 +33,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@react-pdf/renderer": ">=3",
+        "@react-pdf/renderer": ">=3.4.4",
         "react": ">=16"
       }
     },
@@ -536,9 +536,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1005,19 +1006,21 @@
     },
     "node_modules/@react-pdf/fns": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-2.2.1.tgz",
+      "integrity": "sha512-s78aDg0vDYaijU5lLOCsUD+qinQbfOvcNeaoX9AiE7+kZzzCo6B/nX+l48cmt9OosJmvZvE9DWR9cLhrhOi2pA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13"
       }
     },
     "node_modules/@react-pdf/font": {
-      "version": "2.4.4",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-2.5.1.tgz",
+      "integrity": "sha512-Hyb2zBb92Glc3lvhmJfy4dO2Mj29KB26Uk12Ua9EhKAdiuCTLBqgP8Oe1cGwrvDI7xA4OOcwvBMdYh0vhOUHzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/types": "^2.4.1",
+        "@react-pdf/types": "^2.5.0",
         "cross-fetch": "^3.1.5",
         "fontkit": "^2.0.2",
         "is-url": "^1.2.4"
@@ -1025,8 +1028,9 @@
     },
     "node_modules/@react-pdf/image": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-2.3.6.tgz",
+      "integrity": "sha512-7iZDYZrZlJqNzS6huNl2XdMcLFUo68e6mOdzQeJ63d5eApdthhSHBnkGzHfLhH5t8DCpZNtClmklzuLL63ADfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/png-js": "^2.3.1",
@@ -1035,18 +1039,19 @@
       }
     },
     "node_modules/@react-pdf/layout": {
-      "version": "3.11.5",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-3.12.1.tgz",
+      "integrity": "sha512-BxSeykDxvADlpe4OGtQ7NH46QXq3uImAYsTHOPLCwbXMniQ1O3uCBx7H+HthxkCNshgYVPp9qS3KyvQv/oIZwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/fns": "2.2.1",
         "@react-pdf/image": "^2.3.6",
-        "@react-pdf/pdfkit": "^3.1.9",
+        "@react-pdf/pdfkit": "^3.1.10",
         "@react-pdf/primitives": "^3.1.1",
-        "@react-pdf/stylesheet": "^4.2.4",
+        "@react-pdf/stylesheet": "^4.2.5",
         "@react-pdf/textkit": "^4.4.1",
-        "@react-pdf/types": "^2.4.1",
+        "@react-pdf/types": "^2.5.0",
         "cross-fetch": "^3.1.5",
         "emoji-regex": "^10.3.0",
         "queue": "^6.0.1",
@@ -1054,9 +1059,10 @@
       }
     },
     "node_modules/@react-pdf/pdfkit": {
-      "version": "3.1.9",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-3.1.10.tgz",
+      "integrity": "sha512-P/qPBtCFo2HDJD0i6NfbmoBRrsOVO8CIogYsefwG4fklTo50zNgnMM5U1WLckTuX8Qt1ThiQuokmTG5arheblA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/png-js": "^2.3.1",
@@ -1069,27 +1075,30 @@
     },
     "node_modules/@react-pdf/png-js": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-2.3.1.tgz",
+      "integrity": "sha512-pEZ18I4t1vAUS4lmhvXPmXYP4PHeblpWP/pAlMMRkEyP7tdAeHUN7taQl9sf9OPq7YITMY3lWpYpJU6t4CZgZg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/@react-pdf/primitives": {
       "version": "3.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-3.1.1.tgz",
+      "integrity": "sha512-miwjxLwTnO3IjoqkTVeTI+9CdyDggwekmSLhVCw+a/7FoQc+gF3J2dSKwsHvAcVFM0gvU8mzCeTofgw0zPDq0w==",
+      "dev": true
     },
     "node_modules/@react-pdf/render": {
-      "version": "3.4.3",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-3.4.4.tgz",
+      "integrity": "sha512-CfGxWmVgrY3JgmB1iMnz2W6Ck+8pisZeFt8vGlxP+JfT+0onr208pQvGSV5KwA9LGhAdABxqc/+y17V3vtKdFA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/fns": "2.2.1",
         "@react-pdf/primitives": "^3.1.1",
         "@react-pdf/textkit": "^4.4.1",
-        "@react-pdf/types": "^2.4.1",
+        "@react-pdf/types": "^2.5.0",
         "abs-svg-path": "^0.1.1",
         "color-string": "^1.9.1",
         "normalize-svg-path": "^1.1.0",
@@ -1098,17 +1107,18 @@
       }
     },
     "node_modules/@react-pdf/renderer": {
-      "version": "3.4.2",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-3.4.4.tgz",
+      "integrity": "sha512-j1TWMHHXDeHdoQE3xjhBh0MZ2rn7wHIlP/uglr/EJZXqnPbfg6bfLzRJCM6bs+XJV3d8+zLQjHf6sF/fWcBDfg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@react-pdf/font": "^2.4.4",
-        "@react-pdf/layout": "^3.11.5",
-        "@react-pdf/pdfkit": "^3.1.9",
+        "@react-pdf/font": "^2.5.1",
+        "@react-pdf/layout": "^3.12.1",
+        "@react-pdf/pdfkit": "^3.1.10",
         "@react-pdf/primitives": "^3.1.1",
-        "@react-pdf/render": "^3.4.3",
-        "@react-pdf/types": "^2.4.1",
+        "@react-pdf/render": "^3.4.4",
+        "@react-pdf/types": "^2.5.0",
         "events": "^3.3.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
@@ -1120,13 +1130,14 @@
       }
     },
     "node_modules/@react-pdf/stylesheet": {
-      "version": "4.2.4",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-4.2.5.tgz",
+      "integrity": "sha512-XnmapeCW+hDuNdVwpuvO04WKv71wAs8aH+saIq29Bo2fp1SxznHTcQArTZtK6Wgr/E9BHXeB2iAPpUZuI6G+xA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/fns": "2.2.1",
-        "@react-pdf/types": "^2.4.1",
+        "@react-pdf/types": "^2.5.0",
         "color-string": "^1.9.1",
         "hsl-to-hex": "^1.0.0",
         "media-engine": "^1.0.3",
@@ -1135,8 +1146,9 @@
     },
     "node_modules/@react-pdf/textkit": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-4.4.1.tgz",
+      "integrity": "sha512-Jl9wdTqIvJ5pX+vAGz0EOhP7ut5Two9H6CzTKo/YYPeD79cM2yTXF3JzTERBC28y7LR0Waq9D2LHQjI+b/EYUQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@react-pdf/fns": "2.2.1",
@@ -1146,9 +1158,10 @@
       }
     },
     "node_modules/@react-pdf/types": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-XsVRkt0hQ60I4e3leAVt+aZR3KJCaJd179BfJHAv4F4x6Vq3yqkry8lcbUWKGKDw1j3/8sW4FsgGR41SFvsG9A==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -1173,8 +1186,9 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
@@ -1432,8 +1446,9 @@
     },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -1659,6 +1674,8 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
         {
@@ -1673,13 +1690,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -1710,16 +1727,18 @@
     },
     "node_modules/brotli": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
       }
@@ -1908,8 +1927,9 @@
     },
     "node_modules/clone": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -1946,8 +1966,9 @@
     },
     "node_modules/color-string": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -2023,8 +2044,9 @@
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -2044,8 +2066,9 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "dev": true
     },
     "node_modules/css-select": {
       "version": "5.1.0",
@@ -2127,8 +2150,9 @@
     },
     "node_modules/dfa": {
       "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "dev": true
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -2211,8 +2235,9 @@
     },
     "node_modules/emoji-regex": {
       "version": "10.3.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2334,8 +2359,9 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2389,8 +2415,9 @@
     },
     "node_modules/fontkit": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.2.tgz",
+      "integrity": "sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.4.2",
         "brotli": "^1.3.2",
@@ -2531,16 +2558,18 @@
     },
     "node_modules/hsl-to-hex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hsl-to-rgb-for-reals": "^1.1.0"
       }
     },
     "node_modules/hsl-to-rgb-for-reals": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -2591,8 +2620,9 @@
     },
     "node_modules/hyphen": {
       "version": "1.10.4",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.4.tgz",
+      "integrity": "sha512-SejXzIpv9gOVdDWXd4suM1fdF1k2dxZGvuTdkOVLoazYfK7O4DykIQbdrvuyG+EaTNlXAGhMndtKrhykgbt0gg==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -2756,8 +2786,9 @@
     },
     "node_modules/is-url": {
       "version": "1.2.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2827,8 +2858,9 @@
     },
     "node_modules/jay-peg": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.0.2.tgz",
+      "integrity": "sha512-fyV3NVvv6pTys/3BTapBUGAWAuU9rM2gRcgijZHzptd5KKL+s+S7hESFN+wOsbDH1MzFwdlRAXi0aGxS6uiMKg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "restructure": "^3.0.0"
       }
@@ -3535,8 +3567,9 @@
     "node_modules/legacy-swc-helpers": {
       "name": "@swc/helpers",
       "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3741,8 +3774,9 @@
     },
     "node_modules/media-engine": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "dev": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -3792,8 +3826,9 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3837,8 +3872,9 @@
     },
     "node_modules/normalize-svg-path": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "svg-arc-to-cubic-bezier": "^3.0.0"
       }
@@ -3965,8 +4001,9 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3998,8 +4035,9 @@
     },
     "node_modules/parse-svg-path": {
       "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -4126,8 +4164,9 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prettier": {
       "version": "2.8.8",
@@ -4220,8 +4259,9 @@
     },
     "node_modules/queue": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
       }
@@ -4245,8 +4285,9 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4258,8 +4299,9 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4321,8 +4363,9 @@
     },
     "node_modules/restructure": {
       "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.1.tgz",
+      "integrity": "sha512-6neDpI/yE9eogQo22qmWwKIA9wFPRyYjQleDEh6zaNAf2ZPqLJYUvNBJBWEWNoBlCeQMQkvIOe2YI/K2GOag+g==",
+      "dev": true
     },
     "node_modules/rfdc": {
       "version": "1.3.1",
@@ -4339,6 +4382,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -4353,8 +4398,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/scheduler": {
       "version": "0.17.0",
@@ -4421,16 +4465,18 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
       "version": "0.3.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -4492,8 +4538,9 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4611,8 +4658,9 @@
     },
     "node_modules/svg-arc-to-cubic-bezier": {
       "version": "3.2.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "dev": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -4634,8 +4682,9 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -4663,8 +4712,9 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/ts-jest": {
       "version": "29.1.2",
@@ -4793,8 +4843,9 @@
     },
     "node_modules/unicode-properties": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
@@ -4802,8 +4853,9 @@
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
@@ -4811,8 +4863,9 @@
     },
     "node_modules/unicode-trie/node_modules/pako": {
       "version": "0.2.9",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -4845,8 +4898,9 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -4868,8 +4922,9 @@
     },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4889,13 +4944,15 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5023,8 +5080,9 @@
     },
     "node_modules/yoga-layout": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-2.0.1.tgz",
+      "integrity": "sha512-tT/oChyDXelLo2A+UVnlW9GU7CsvFMaEnd9kVFsaiCQonFAXd3xrHhkLYu+suwwosrAEQ746xBU+HvYtm1Zs2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "node-html-parser": "^6.1.13"
   },
   "peerDependencies": {
-    "@react-pdf/renderer": ">=3",
+    "@react-pdf/renderer": ">=3.4.4",
     "react": ">=16"
   },
   "devDependencies": {
-    "@react-pdf/renderer": "^3.0.0",
+    "@react-pdf/renderer": "^3.4.4",
     "@types/css-tree": "^1.0.7",
     "@types/jest": "^25.2.3",
     "@types/node": "^14.0.25",

--- a/src/parse.test.tsx
+++ b/src/parse.test.tsx
@@ -79,6 +79,17 @@ describe('parse', () => {
 
       expect(result).toEqual(expected);
     });
+
+    it('Should support fallback fonts', () => {
+      const content = `font-family: "Helvetica Neue", Helvetica, 'Noto Sans', sans-serif`;
+
+      const result = convertElementStyle(content, 'div');
+      const expected = {
+        fontFamily: ['Helvetica Neue', 'Helvetica', 'Noto Sans', 'sans-serif'],
+      };
+
+      expect(result).toEqual(expected);
+    });
   });
 
   describe('parseHtml', () => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -43,11 +43,7 @@ export const convertRule = (
       let valueString: string | string[] = generate(value);
       if (property && value) {
         if (property === 'fontFamily') {
-          valueString = valueString.replace(/["']+/g, '');
-          if (valueString.includes(',')) {
-            const splitValue = valueString.split(',');
-            valueString = splitValue;
-          }
+          valueString = valueString.replace(/["']+/g, '').split(',');
         } else if (!supportedStyles.includes(property)) {
           if (
             (property === 'background' &&

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -40,16 +40,14 @@ export const convertRule = (
       property: camelize(entry.property as string),
     }))
     .reduce((style, { property, value }: Declaration) => {
-      let valueString = generate(value);
+      let valueString: string | string[] = generate(value);
       if (property && value) {
         if (property === 'fontFamily') {
+          console.log('fontFamily', valueString);
           valueString = valueString.replace(/["']+/g, '');
           if (valueString.includes(',')) {
-            const reduced = valueString.split(',', 2)[0];
-            console.warn(
-              `react-pdf doesn't support fontFamily lists like "${valueString}". Reducing to "${reduced}".`
-            );
-            valueString = reduced;
+            const splitValue = valueString.split(',');
+            valueString = splitValue;
           }
         } else if (!supportedStyles.includes(property)) {
           if (

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -43,7 +43,6 @@ export const convertRule = (
       let valueString: string | string[] = generate(value);
       if (property && value) {
         if (property === 'fontFamily') {
-          console.log('fontFamily', valueString);
           valueString = valueString.replace(/["']+/g, '');
           if (valueString.includes(',')) {
             const splitValue = valueString.split(',');


### PR DESCRIPTION
`@react-pdf/render` recently introduced font family fallback support in version `3.4.4`:
https://github.com/diegomura/react-pdf/pull/2640

Description of changes
* Bumped peer and dev dependency to `3.4.4` for `@react-pdf/render` 
* Changed parsing strategy for `fontFamily` to split by `,` and return the resulting array