### PR TITLE
Adapt fix for commonjs css-tree import failure

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -7,8 +7,7 @@ import {
 } from 'node-html-parser';
 import { Tag } from './tags.js';
 import { Block, Declaration, List, Rule, StyleSheet } from 'css-tree';
-import * as cssTree from 'css-tree';
-const { generate, parse: cssParse } = cssTree;
+import { generate, parse as cssParse } from 'css-tree';
 
 import supportedStyles from './supportedStyles.js';
 import { HtmlStyle, HtmlStyles } from './styles.js';


### PR DESCRIPTION
Aiming to close #89. The test suite passes and the build succeeds.