### PR TITLE
Handle `start` attribute for `ol`s

### DIFF
--- a/src/renderers.tsx
+++ b/src/renderers.tsx
@@ -158,7 +158,9 @@ const renderers: HtmlRenderers = {
           <Text>{orderedAlpha[element.indexOfType].toUpperCase()}.</Text>
         );
       } else {
-        bullet = <Text>{element.indexOfType + 1}.</Text>;
+        const start = parseInt(element.parentNode.attributes.start);
+        const offset = isNaN(start) ? 1 : start;
+        bullet = <Text>{element.indexOfType + offset}.</Text>;
       }
     } else {
       // if (listStyleType.includes('square')) {


### PR DESCRIPTION
Fixes #97

I couldn't work out how to get tests working for this, but seems to work fine in my example setup using a custom `li` renderer as a prop to `Html`