### PR TITLE
fix: potential crash on text nodes in ordered list

### DIFF
--- a/src/renderers.tsx
+++ b/src/renderers.tsx
@@ -26,7 +26,6 @@ import { HtmlStyle } from './styles.js';
 import { lowerAlpha, orderedAlpha, upperAlpha } from './ordered.type.js';
 import { Style } from '@react-pdf/types';
 import camelize from './camelize.js';
-import HTMLElement from 'node-html-parser/dist/nodes/html';
 
 export const renderNoop: HtmlRenderer = ({ children }) => <></>;
 
@@ -182,21 +181,27 @@ const renderers: HtmlRenderers = {
       const offset = isNaN(start) ? 0 : start - 1; // keep it zero based for later
 
       let updatedIndex = currentIndex + offset;
-      for (
-        let previousIndex = currentIndex;
-        previousIndex >= 0;
-        previousIndex -= 1
-      ) {
-        const sibling: HTMLElement = element.parentNode.childNodes[
-          previousIndex
-        ] as HTMLElement;
-        const startValue = parseInt(sibling.attributes.value, 10);
+      let currentElement: HtmlElement | null = element;
+      let sibling: HtmlElement | null = currentElement;
+      do {
+        currentElement = sibling;
+        sibling = currentElement.previousElementSibling as HtmlElement | null;
 
-        if (!isNaN(startValue)) {
-          updatedIndex = startValue + (currentIndex - previousIndex) - 1;
+        if (!currentElement) {
           break;
         }
-      }
+        if (currentElement.tag !== 'li') {
+          // skip all other element types because they do not belong in a list
+          continue;
+        }
+        const startValue = parseInt(currentElement.attributes.value, 10);
+
+        if (!isNaN(startValue)) {
+          updatedIndex =
+            startValue + (currentIndex - currentElement.indexOfType) - 1;
+          break;
+        }
+      } while (!!sibling);
 
       if (lowerAlpha.includes(listStyleType)) {
         bullet = <Text>{orderedAlpha[updatedIndex].toLowerCase()}.</Text>;


### PR DESCRIPTION
Fixes a little bug I introduced with #87 

We were using minified html, but when using formatted html (with indents and newlines) there are text nodes between list items.

While I was at it also ignoring other tag types.

One concern I have is this type casting:
```typescript
sibling = currentElement.previousElementSibling as HtmlElement | null;
``` 

It was needed to get the `tag` and `indexOfType` properties. Those are actually available here, but not typed.