### PR TITLE
Fix css-tree import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-pdf-html",
-  "version": "2.0.4",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-pdf-html",
-      "version": "2.0.4",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^1.1.3",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -7,7 +7,7 @@ import {
 } from 'node-html-parser';
 import { Tag } from './tags.js';
 import { Block, Declaration, List, Rule, StyleSheet } from 'css-tree';
-import * as cssTree from 'css-tree';
+import cssTree from 'css-tree';
 const { generate, parse: cssParse } = cssTree;
 
 import supportedStyles from './supportedStyles.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,8 @@
     //    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */


### PR DESCRIPTION
I had an issue with my ESM build related to css-tree import (related to https://github.com/danomatic/react-pdf-html/issues/89)

Had to do some digging here, but I believe I have found the root issue:

css-tree's index.d.ts does not match their actual distributed code. Their index.d.ts file says that there is NO default export so if we would do this:
```typescript
import cssTree from 'css-tree';
```
we would get a TypeScript error.

But when inspecting in css-tree's node_modules I see the following:

In package.json their main is "lib/index.js", and that file is `module.exports = require('./syntax');`, which is a default export.

Ideally they would fix this, but a "quickfix" for our case is to specify 

```jsonc
// compilerOptions in tsconfig
    "esModuleInterop": true,
    "allowSyntheticDefaultImports": true,
```
such that we can do 
```typescript
import cssTree from 'css-tree';
```
without getting any errors.

### Something unexplainable

I still don't get how jest have managed to make it work though, but it could be how jest does dynamic imports that allows jest to not crash in this case. Either way jest still works with these changes.

### Tested
I have tested this change on my ESM project and it fixed it. I have not tested this on a CJS project, but I think it should work.


