### PR TITLE
Add support for gap, columnGap, rowGap and zIndex CSS properties

### DIFF
--- a/src/supportedStyles.ts
+++ b/src/supportedStyles.ts
@@ -11,6 +11,9 @@ export default [
   'flexBasis',
   'justifyContent',
   'order',
+  'gap',
+  'columnGap',
+  'rowGap',
 
   // Layout
   'bottom',
@@ -20,6 +23,7 @@ export default [
   'right',
   'top',
   'overflow',
+  'zIndex',
 
   // Dimension
   'height',


### PR DESCRIPTION
This PR adds support for the following CSS properties to the list of supported styles in react-pdf-html:

gap

columnGap

rowGap

zIndex

These properties are already supported by react-pdf ([reference](https://react-pdf.org/styling#valid-css-properties))